### PR TITLE
Add Watsonx as Provider

### DIFF
--- a/.github/workflows/notebook-testing.yaml
+++ b/.github/workflows/notebook-testing.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.8"
+          python-version: "3.10"
 
       - name: Install dependencies
         run: |
@@ -30,10 +30,18 @@ jobs:
         run: |
           pip install -e .  
 
+      - name: Set Python Path
+        run: |
+          echo "PYTHONPATH=$GITHUB_WORKSPACE" >> $GITHUB_ENV
+
       - name: Run Jupyter Notebooks
         env:
           REPLICATE_API_TOKEN: ${{ secrets.REPLICATE_API_TOKEN }}
+          WATSONX_APIKEY: ${{ secrets.WATSONX_APIKEY }}
+          WATSONX_PROJECT_ID: ${{ secrets.WATSONX_PROJECT_ID }}
+          WATSONX_URL: ${{ secrets.WATSONX_URL }}
         run: |
+          echo "PYTHONPATH=$PYTHONPATH"
           for notebook in $(find . -name '*.ipynb'); do  
             echo "Executing $notebook"  
             jupyter nbconvert --to notebook --execute --inplace $notebook  

--- a/examples/Basic_Usage.ipynb
+++ b/examples/Basic_Usage.ipynb
@@ -2,38 +2,22 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {
-    "id": "gGyVx2RyJ128"
-   },
-   "outputs": [],
-   "source": [
-    "import os\n",
-    "from ibm_granite_community.notebook_utils import is_colab\n",
-    "\n",
-    "if is_colab():\n",
-    "    from google.colab import userdata\n",
-    "    os.environ['REPLICATE_API_TOKEN'] = userdata.get('REPLICATE_API_TOKEN')"
-   ]
-  },
-  {
-   "cell_type": "code",
    "execution_count": null,
    "metadata": {
     "id": "8AY6igsZ2QTm"
    },
    "outputs": [],
    "source": [
-    "!pip install git+https://github.com/ibm-granite-community/utils"
+    "!pip install git+https://github.com/ibm-granite-community/utils -U"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "!pip install langchain-core"
+    "Or, for utils development, install the local utils package in editable mode:\n",
+    "\n",
+    "`pip install -e ../. -U`"
    ]
   },
   {
@@ -55,6 +39,7 @@
    },
    "outputs": [],
    "source": [
+    "import os\n",
     "os.system(\"nohup ollama serve &\")"
    ]
   },
@@ -71,7 +56,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 1,
    "metadata": {
     "id": "qTXzIbRN2hJ6",
     "pycharm": {
@@ -81,9 +66,18 @@
    "outputs": [],
    "source": [
     "from ibm_granite_community.langchain_utils import find_langchain_model\n",
+    "from ibm_granite_community.notebook_utils import get_env_var\n",
     "\n",
-    "colab_model = find_langchain_model(platform=\"Replicate\", model_id= \"ibm-granite/granite-8b-code-instruct-128k\")\n",
-    "ollama_model = find_langchain_model(platform=\"ollama\", model_id= \"granite-code:8b\")\n"
+    "replicate_model = find_langchain_model(platform=\"Replicate\", model_id= \"ibm-granite/granite-8b-code-instruct-128k\")\n",
+    "ollama_model = find_langchain_model(platform=\"ollama\", model_id= \"granite-code:8b\")\n",
+    "watsonx_model = find_langchain_model(platform=\"watsonx\", model_id= \"ibm/granite-13b-chat-v2\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Use the models to complete a prompt"
    ]
   },
   {
@@ -99,11 +93,12 @@
    "outputs": [],
    "source": [
     "prompt = \"\"\"\n",
-    "Complete this famous phrase: a shark on whisky is might risky, a shark on beer is\n",
+    "Complete this famous phrase: a shark on whisky is mighty risky, a shark on beer is\n",
     "\"\"\"\n",
     "\n",
-    "print(f\"Colab: {colab_model.invoke(prompt)}\")\n",
-    "print(f\"Ollama: {ollama_model.invoke(prompt)}\")\n"
+    "print(f\"Replicate: {replicate_model.invoke(prompt)}\")\n",
+    "print(f\"Ollama: {ollama_model.invoke(prompt)}\")\n",
+    "print(f\"WatsonX: {watsonx_model.invoke(prompt)}\")\n"
    ]
   },
   {
@@ -115,7 +110,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/ibm_granite_community/langchain_utils.py
+++ b/ibm_granite_community/langchain_utils.py
@@ -1,9 +1,9 @@
-from ibm_granite_community.notebook_utils import set_api_key
+from ibm_granite_community.notebook_utils import set_env_var, get_env_var
 
 def find_langchain_model(platform, model_id, **model_kwargs):
     if platform.lower() == "replicate":
         from langchain_community.llms import Replicate
-        set_api_key()
+        set_env_var('REPLICATE_API_TOKEN')
         model = Replicate(
             model=model_id,
             model_kwargs=model_kwargs
@@ -11,6 +11,17 @@ def find_langchain_model(platform, model_id, **model_kwargs):
     elif platform.lower() == "ollama":
         from langchain_ollama.llms import OllamaLLM
         model = OllamaLLM(model=model_id, **model_kwargs)
+    elif platform.lower() == "watsonx":
+        from langchain_ibm import WatsonxLLM
+        model = WatsonxLLM(
+            model_id=model_id, 
+            url= get_env_var("WATSONX_URL"),
+            apikey=get_env_var("WATSONX_APIKEY"),
+            project_id=get_env_var("WATSONX_PROJECT_ID"),
+            **model_kwargs
+        )
+    else:
+        raise ValueError(f"Platform {platform} not supported.")
     return model
 
 

--- a/ibm_granite_community/notebook_utils.py
+++ b/ibm_granite_community/notebook_utils.py
@@ -9,41 +9,45 @@ def is_colab():
         return False
 
 # Function to get the API key
-def get_api_key():
-    api_key = None
+def get_env_var(var_name):
+    env_var = None
+
+    if os.environ.get(var_name) is not None:
+        return os.environ.get(var_name)
 
     if is_colab():
         # If in Google Colab, try to get the API key from a secret
         from google.colab import userdata
         try:
-            api_key = userdata.get('REPLICATE_API_TOKEN')
-            if api_key:
-                print("API key loaded from Google Colab secret.")
+            env_var = userdata.get(var_name)
+            if env_var:
+                print(f"{var_name} loaded from Google Colab secret.")
         except userdata.SecretNotFoundError:
-            print("REPLICATE_API_TOKEN not found in Google Colab secrets.")
+            print(f"{var_name} not found in Google Colab secrets.")
 
-    if not api_key and os.path.exists('.env'):
+    if not env_var and os.path.exists('.env'):
         # Try to load API key from .env file
         try:
             from dotenv import load_dotenv
             load_dotenv()
         except ModuleNotFoundError:
             print("Module 'dotenv' not found. Please install it using 'pip install python-dotenv'.")
-        api_key = os.getenv('REPLICATE_API_TOKEN')
-        if api_key:
-            print("API key loaded from .env file.")
+        env_var = os.getenv(var_name)
+        if env_var:
+            print(f"{var_name} loaded from .env file.")
         else:
-            print("REPLICATE_API_TOKEN not found in .env file.")
-    if not api_key:
+            print(f"{var_name} not found in .env file.")
+
+    if not env_var:
         # If neither Colab nor .env file, prompt the user for the API key
         from getpass import getpass
-        api_key = getpass("Please enter your API key: ")
+        env_var = getpass(f"Please enter your {var_name}: ")
 
-    if not api_key:
-        raise ValueError("API key could not be loaded from any source.")
+    if not env_var:
+        raise ValueError(f"{var_name} could not be loaded from any source.")
 
-    return api_key
+    return env_var
 
-def set_api_key():
-  if os.environ.get('REPLICATE_API_TOKEN') is None:
-    os.environ['REPLICATE_API_TOKEN'] = get_api_key()
+def set_env_var(var_name):
+    if os.environ.get(var_name) is None:
+        os.environ[var_name] = get_env_var(var_name)

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(
         "langchain-pinecone",
         "langchain-milvus",
         "langchain-chroma",
+        "langchain_ibm",
     ],
     author='The IBM Granite Community Team',
     author_email='trevor.d.grant@gmail.com',


### PR DESCRIPTION
[#124](https://github.com/ibm-granite-community/pm/issues/124) Add WatsonX as a Provider:
- Generalize get_api_key() and set_api_key() for any env var.
- Add "watsonx" to find_langchain_model()
- Update BasicUsage notebook