### PR TITLE
Link from Langchain LLMs to Getting Started

### DIFF
--- a/recipes/Components/Langchain_LLMs.ipynb
+++ b/recipes/Components/Langchain_LLMs.ipynb
@@ -24,7 +24,7 @@
    "source": [
     "### Replicate\n",
     "\n",
-    "For instructions on how to set up Replicate, see [Getting Started with Replicate](/recipes/Getting_Started/Getting_Started_with_Replicate.ipynb).\n",
+    "For instructions on how to set up Replicate, see [Getting Started with Replicate](../Getting_Started/Getting_Started_with_Replicate.ipynb).\n",
     "\n",
     "To select a Granite model, go to the [`ibm-granite`](https://replicate.com/ibm-granite) org on Replicate."
    ]
@@ -50,7 +50,7 @@
    "source": [
     "### Ollama\n",
     "\n",
-    "For instructions on how to set up Ollama, see [Getting Started with Ollama](/recipes/Getting_Started/Getting_Started_with_Ollama.ipynb).\n",
+    "For instructions on how to set up Ollama, see [Getting Started with Ollama](../Getting_Started/Getting_Started_with_Ollama.ipynb).\n",
     "\n",
     "To select a Granite Code model, go to the [Ollama granite code library](https://ollama.com/library/granite-code)."
    ]
@@ -72,7 +72,7 @@
    "source": [
     "### WatsonX\n",
     "\n",
-    "For instructions on how to set up WatsonX, see [Getting Started with WatsonX](/recipes/Getting_Started/Getting_Started_with_WatsonX.ipynb).\n",
+    "For instructions on how to set up WatsonX, see [Getting Started with WatsonX](../Getting_Started/Getting_Started_with_WatsonX.ipynb).\n",
     "\n",
     "To select a Granite model, go to the [list of Foundation Models](https://www.ibm.com/products/watsonx-ai/foundation-models) on WatsonX."
    ]

--- a/recipes/Components/Langchain_LLMs.ipynb
+++ b/recipes/Components/Langchain_LLMs.ipynb
@@ -24,7 +24,9 @@
    "source": [
     "### Replicate\n",
     "\n",
-    "Granite models are available in the [`ibm-granite`](https://replicate.com/ibm-granite) org at Replicate."
+    "For instructions on how to set up Replicate, see [Getting Started with Replicate](/recipes/Getting_Started/Getting_Started_with_Replicate.ipynb).\n",
+    "\n",
+    "To select a Granite model, go to the [`ibm-granite`](https://replicate.com/ibm-granite) org on Replicate."
    ]
   },
   {
@@ -48,7 +50,9 @@
    "source": [
     "### Ollama\n",
     "\n",
-    "Granite Code models are hosted in the [Ollama granite code library](https://ollama.com/library/granite-code)."
+    "For instructions on how to set up Ollama, see [Getting Started with Ollama](/recipes/Getting_Started/Getting_Started_with_Ollama.ipynb).\n",
+    "\n",
+    "To select a Granite Code model, go to the [Ollama granite code library](https://ollama.com/library/granite-code)."
    ]
   },
   {
@@ -68,7 +72,9 @@
    "source": [
     "### WatsonX\n",
     "\n",
-    "The Granite models available on WatsonX are listed [here](https://www.ibm.com/products/watsonx-ai/foundation-models)."
+    "For instructions on how to set up WatsonX, see [Getting Started with WatsonX](/recipes/Getting_Started/Getting_Started_with_WatsonX.ipynb).\n",
+    "\n",
+    "To select a Granite model, go to the [list of Foundation Models](https://www.ibm.com/products/watsonx-ai/foundation-models) on WatsonX."
    ]
   },
   {


### PR DESCRIPTION
- Add links from Langchain_LLMs recipe to the corresponding Getting_Started recipe for Ollama, Replicate, and WatsonX.

Full recipes will link to Langchain_LLMs to swap out provider, so it will be helpful to link to additional guidance for provider setup.