### PR TITLE
ci: Add support for testing a PR via a workflow_dispatch

### DIFF
--- a/.github/workflows/test_notebook.yaml
+++ b/.github/workflows/test_notebook.yaml
@@ -41,6 +41,11 @@ on:
         type: string
         default: |
           jupyter nbconvert --to notebook --execute --inplace {0}
+      ref:
+        description: 'Git ref to checkout'
+        required: false
+        type: string
+        default: ''
       all:
         description: 'Whether to test all notebooks or just changed notebooks'
         required: false
@@ -73,6 +78,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
 
       - name: Find all notebook files
         if: ${{ fromJSON(inputs.all) }}
@@ -111,6 +118,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
 
       - name: Prepare Additional Test Setup action
         if: ${{ inputs.action && hashFiles(format('{0}/action.yml',inputs.action),format('{0}/action.yaml',inputs.action)) }}


### PR DESCRIPTION
## PR Checklist

### GitHub

- [x] **Commits signed**: All commits must be GPG or SSH signed.
- [x] **DCO Compliance**: Developer Certificate of Origin (DCO) applies to the code, documentation, and any example data provided. Ensure commits are signed off.

This change allows a workflow to specify the ref to checkout. So we can have a workflow_dispatch workflow which takes a PR number to checkout. The plan is to
allow maintainer to test the PR with the secrets in a workflow_dispatch workflow after
reviewing the PR.