### PR TITLE
ci: Enable explicit secret passing

### DIFF
--- a/.github/workflows/test_notebook.yaml
+++ b/.github/workflows/test_notebook.yaml
@@ -56,6 +56,15 @@ on:
         required: false
         type: string
         default: ''
+    secrets:
+      REPLICATE_API_TOKEN:
+        required: false
+      WATSONX_APIKEY:
+        required: false
+      WATSONX_PROJECT_ID:
+        required: false
+      WATSONX_URL:
+        required: false
 
 env:
   LC_ALL: en_US.UTF-8


### PR DESCRIPTION
When using this file (from its main repo), a recipe repo fork cannot use secrets: inherit to pass secrets across the organization boundary.

So we need to allow for explicit secret passing, where the forks secret values can be passed to this called workflow.

## PR Checklist

### GitHub

- [x] **Commits signed**: All commits must be GPG or SSH signed.
- [x] **DCO Compliance**: Developer Certificate of Origin (DCO) applies to the code, documentation, and any example data provided. Ensure commits are signed off.
