### PR TITLE
Add wrap_text util method so notebook output can be wrapped

### DIFF
--- a/src/ibm_granite_community/notebook_utils.py
+++ b/src/ibm_granite_community/notebook_utils.py
@@ -1,5 +1,6 @@
 import importlib.util
 import os
+import textwrap
 
 from dotenv import find_dotenv, load_dotenv
 
@@ -90,3 +91,19 @@ def set_env_var(var_name: str, default_value: str | None) -> None:
         default_value (str | None): A default value to use.
     """
     get_env_var(var_name, default_value)
+
+
+def wrap_text(text: str, width: int = 80, indent: str = "") -> str:
+    """Wrap the specified text to display better in the notebook output.
+
+    Args:
+        text (str): The text string to wrap. This string can include multiple lines.
+        width (int, optional): The wrapping width. Defaults to 80.
+        indent (str, optional): The indent string to use for each line in the result. Defaults to "".
+
+    Returns:
+        str: The specified string wrapped to the specified width and indented with the specified indent.
+    """
+    lines = text.splitlines()
+    wrapped_lines = (textwrap.fill(line, width, initial_indent=indent, subsequent_indent=indent) for line in lines)
+    return "\n".join(wrapped_lines)

--- a/tests/test_notebook_utils.py
+++ b/tests/test_notebook_utils.py
@@ -3,9 +3,10 @@
 import getpass
 import pathlib
 
+import pytest
 from assertpy import assert_that
 
-from ibm_granite_community.notebook_utils import get_env_var, set_env_var
+from ibm_granite_community.notebook_utils import get_env_var, set_env_var, wrap_text
 
 
 # Test retrieval of new environment variable
@@ -49,3 +50,20 @@ def test_env_var_default():
 def test_set_env_var_default():
     set_env_var("FAVORITE_COLOR2", "green")
     assert_that(get_env_var("FAVORITE_COLOR2")).is_equal_to("green")
+
+
+@pytest.mark.parametrize("width,indent", [(30, ""), (50, ""), (80, ""), (30, "  "), (50, "* "), (80, "> "), (200, ""), (200, "> ")])
+def test_wrap_text(width: int, indent: str):
+    wide_string = """\
+This string is long and thus should be wrapped so that there are multiple lines each less than the requested width.
+"""
+    wrapped = wrap_text(wide_string, width=width, indent=indent)
+    splitlines = wrapped.splitlines()
+    if len(wide_string) > width:
+        assert_that(len(splitlines), "len(splitlines)").is_greater_than_or_equal_to(2)
+    else:
+        assert_that(len(splitlines), "len(splitlines)").is_equal_to(1)
+    for line in splitlines:
+        assert_that(len(line), "len(line)").is_less_than_or_equal_to(width)
+        if len(indent) > 0:
+            assert_that(line).starts_with(indent)


### PR DESCRIPTION
This can be used by notebooks to enable better readability of wide output.

## PR Checklist

### GitHub

- [x] **Commits signed**: All commits must be GPG or SSH signed.
- [x] **DCO Compliance**: Developer Certificate of Origin (DCO) applies to the code, documentation, and any example data provided. Ensure commits are signed off.
