### PR TITLE
Avoid changing the message.content value

### DIFF
--- a/src/ibm_granite_community/langchain/tokenizer_chat.py
+++ b/src/ibm_granite_community/langchain/tokenizer_chat.py
@@ -80,11 +80,7 @@ def _conversation_message(message: BaseMessage) -> dict[str, Any]:
         raise ValueError(msg)  # noqa: TRY004
 
     conversation_message["role"] = role
-    conversation_message["content"] = (
-        message.text()
-        if not isinstance(message.content, str) and all(isinstance(item, str) or (item.get("type") == "text" and isinstance(item.get("text"), str)) for item in message.content)
-        else message.content
-    )
+    conversation_message["content"] = message.content
     return conversation_message
 
 

--- a/tests/test_tokenizer_chat.py
+++ b/tests/test_tokenizer_chat.py
@@ -58,7 +58,7 @@ class TestTokenizerChatTemplate:
         prompt_template = TokenizerChatPromptTemplate.from_messages(
             [
                 SystemMessage(content="system content"),
-                HumanMessage(content=[{"type": "text", "text": "user content1\n"}, {"type": "text", "text": "user content2\n"}]),
+                HumanMessage(content="user content1\nuser content2\n"),
                 ChatMessage(role="User", content="chat content"),
                 AIMessage(content="assistant content"),
             ],
@@ -80,7 +80,7 @@ class TestTokenizerChatTemplate:
         prompt_template = TokenizerChatPromptTemplate.from_messages(
             [
                 SystemMessage(content="system content"),
-                HumanMessage(content=[{"type": "text", "text": "user content1\n"}, {"type": "text", "text": "user content2\n"}]),
+                HumanMessage(content="user content1\nuser content2\n"),
                 ChatMessage(role="User", content="chat content"),
                 AIMessage(content="assistant content"),
             ],


### PR DESCRIPTION
We cannot know if the prompt template can handle a string instead of an array. So we require the user to supply the proper value type.

## PR Checklist

### GitHub

- [x] **Commits signed**: All commits must be GPG or SSH signed.
- [x] **DCO Compliance**: Developer Certificate of Origin (DCO) applies to the code, documentation, and any example data provided. Ensure commits are signed off.
