### PR TITLE
Remove python 3.10 from CI testing

### DIFF
--- a/.github/workflows/test_notebook.yaml
+++ b/.github/workflows/test_notebook.yaml
@@ -27,6 +27,7 @@ on:
         type: string
         default: >-
           3.11
+          3.12
       pip-install:
         description: 'Space-separated dependencies to pip install'
         required: false
@@ -35,6 +36,7 @@ on:
           nbconvert
           nbclient
           ipykernel
+          ipywidgets
       command:
         description: 'Newline-separated commands to test notebook'
         required: false

--- a/.github/workflows/unit-testing.yaml
+++ b/.github/workflows/unit-testing.yaml
@@ -34,7 +34,6 @@ jobs:
     strategy:
       matrix:
         python:
-          - '3.10'
           - '3.11'
           - '3.12'
           - '3.13'


### PR DESCRIPTION
We remove 3.10 since some recipe notebooks have dependencies which require 3.11+.

