### PR TITLE
Make sure to pass documents to llm

### DIFF
--- a/src/ibm_granite_community/langchain/tokenizer_chat.py
+++ b/src/ibm_granite_community/langchain/tokenizer_chat.py
@@ -8,11 +8,12 @@ which works with a transformers tokenizer's apply_chat_template method's documen
 """
 
 import json
-from collections.abc import Sequence
-from typing import Any, cast
+from collections.abc import Callable, Mapping, Sequence
+from functools import partial
+from typing import Any
 
 from langchain_core.documents import Document
-from langchain_core.language_models import LanguageModelLike
+from langchain_core.language_models import LanguageModelInput, LanguageModelLike, LanguageModelOutput
 from langchain_core.messages import (
     AIMessage,
     BaseMessage,
@@ -31,7 +32,7 @@ from langchain_core.prompts import (
 )
 from langchain_core.prompts.chat import MessageLikeRepresentation
 from langchain_core.prompts.string import PromptTemplateFormat
-from langchain_core.runnables import Runnable, RunnableConfig, RunnablePassthrough
+from langchain_core.runnables import Runnable, RunnableConfig, RunnablePassthrough, chain
 from typing_extensions import Self, override
 
 
@@ -60,8 +61,8 @@ def _conversation_message(message: BaseMessage) -> dict[str, Any]:
         if message.tool_calls:  # Fix up for OpenAI conventions
             conversation_message["tool_calls"] = [
                 {
-                    "id": tool_call.get("id"),
                     "type": "function",
+                    "id": tool_call.get("id"),
                     "function": {
                         "name": tool_call["name"],
                         "arguments": json.dumps(tool_call["args"]),
@@ -87,29 +88,30 @@ def _conversation_message(message: BaseMessage) -> dict[str, Any]:
 class TokenizerChatPromptValue(ChatPromptValue):
     """Tokenizer chat prompt value
 
-    A type of a prompt value that is built from messages using
-    a transformers tokenizer apply_chat_template method to format the messages
+    A type of a prompt value whose string is built from messages using
+    a transformers tokenizer's apply_chat_template method to format the messages
     into a prompt string.
     """
 
-    text: str
-    """Prompt formatted by a transformers tokenizer apply_chat_template method."""
+    apply_chat_template: Callable[[Sequence[Mapping[str, Any]]], str]
+    """Prompt formatter using transformers tokenizer's apply_chat_template method."""
 
     @override
     def to_string(self) -> str:
-        """Return prompt formatted by a transformers tokenizer apply_chat_template method."""
-        return self.text
+        """Return prompt formatted by a transformers tokenizer's apply_chat_template method."""
+        conversation = [_conversation_message(message) for message in self.messages]
+        return self.apply_chat_template(conversation)
 
     @classmethod
-    def get_lc_namespace(cls) -> list[str]:
-        """Get the namespace of the langchain object."""
-        return ["langchain", "prompts", "tokenizer"]
+    def is_lc_serializable(cls) -> bool:
+        """This class is not serializable."""
+        return False
 
 
 class TokenizerChatPromptTemplate(ChatPromptTemplate):
     """Tokenizer chat prompt template
 
-    Prompt Template using a transformers tokenizer apply_chat_template method
+    Prompt Template using a transformers tokenizer's apply_chat_template method
     to format the messages into a prompt string.
 
     Any arguments bound to the prompt will be included in the arguments
@@ -119,7 +121,7 @@ class TokenizerChatPromptTemplate(ChatPromptTemplate):
 
     tokenizer: Any
     """The transformers tokenizer for the model to use apply_chat_template
-    method to format the prompt"""
+    method to format the prompt string"""
 
     def __init__(
         self,
@@ -133,8 +135,8 @@ class TokenizerChatPromptTemplate(ChatPromptTemplate):
 
         Args:
             messages (Sequence[MessageLikeRepresentation]): The messages for the prompt.
-            tokenizer: The transformers tokenizer to use apply_chat_template
-            method to format the prompt.
+            tokenizer: The transformers tokenizer whose apply_chat_template
+            method will be used to format the prompt string.
             template_format (PromptTemplateFormat, optional): The format for the message
             templates. Defaults to "f-string".
         """
@@ -146,9 +148,9 @@ class TokenizerChatPromptTemplate(ChatPromptTemplate):
         )
 
     @classmethod
-    def get_lc_namespace(cls) -> list[str]:
-        """Get the namespace of the langchain object."""
-        return ["langchain", "prompts", "tokenizer"]
+    def is_lc_serializable(cls) -> bool:
+        """This class is not serializable."""
+        return False
 
     @classmethod
     def from_template(  # type: ignore[override] # pylint: disable=arguments-differ
@@ -161,8 +163,8 @@ class TokenizerChatPromptTemplate(ChatPromptTemplate):
 
         Args:
             template: template string
-            tokenizer: The transformers tokenizer to use apply_chat_template
-            method to format the prompt.
+            tokenizer: The transformers tokenizer whose apply_chat_template
+            method will be used to format the prompt string.
             **kwargs: keyword arguments to pass to the constructor.
 
         Returns:
@@ -210,16 +212,16 @@ class TokenizerChatPromptTemplate(ChatPromptTemplate):
                   (4) 2-tuple of (message class, template), (5) a string which is
                   shorthand for ("human", template); e.g., "{user_input}".
             template_format: format of the message templates. Defaults to "f-string".
-            tokenizer: The transformers tokenizer to use apply_chat_template
-                method to format the prompt.
+            tokenizer: The transformers tokenizer whose apply_chat_template
+                method will be used to format the prompt string.
 
         Returns:
             A new instance of this class.
         """
         return cls(messages=messages, tokenizer=tokenizer, template_format=template_format)
 
-    def _apply_chat_template(self, messages: list[BaseMessage], **kwargs: Any) -> TokenizerChatPromptValue:
-        """Apply the tokenizer's chat template to the formatted messages and kwargs.
+    def _prompt_value(self, messages: Sequence[BaseMessage], **kwargs: Any) -> TokenizerChatPromptValue:
+        """Create a TokenizerChatPromptValue for the formatted messages and kwargs.
 
         Args:
             messages (list[BaseMessage]): The formatted messages.
@@ -228,17 +230,13 @@ class TokenizerChatPromptTemplate(ChatPromptTemplate):
         Returns:
             TokenizerChatPromptValue: The PromptValue
         """
-        conversation = [_conversation_message(message) for message in messages]
-        prompt = cast(
-            str,
-            self.tokenizer.apply_chat_template(
-                conversation=conversation,
-                tokenize=False,  # output is str
-                add_generation_prompt=True,
-                **kwargs,
-            ),
+        apply_chat_template: Callable[[Sequence[Mapping[str, Any]]], str] = partial(
+            self.tokenizer.apply_chat_template,
+            tokenize=False,  # output is str
+            add_generation_prompt=True,
+            **kwargs,
         )
-        return TokenizerChatPromptValue(text=prompt, messages=messages)
+        return TokenizerChatPromptValue(apply_chat_template=apply_chat_template, messages=messages)
 
     @override
     def format_prompt(self, **kwargs: Any) -> PromptValue:  # type: ignore[override]
@@ -254,7 +252,7 @@ class TokenizerChatPromptTemplate(ChatPromptTemplate):
             PromptValue.
         """
         messages = self.format_messages(**kwargs)
-        return self._apply_chat_template(messages, **kwargs)
+        return self._prompt_value(messages, **kwargs)
 
     @override
     async def aformat_prompt(self, **kwargs: Any) -> PromptValue:  # type: ignore[override]
@@ -270,7 +268,7 @@ class TokenizerChatPromptTemplate(ChatPromptTemplate):
             PromptValue.
         """
         messages = await self.aformat_messages(**kwargs)
-        return self._apply_chat_template(messages, **kwargs)
+        return self._prompt_value(messages, **kwargs)
 
     @override
     def invoke(
@@ -329,7 +327,8 @@ def create_stuff_documents_chain(
         using a TokenizerChatPromptTemplate.
 
     Args:
-        llm: Language model.
+        llm: Language model. Prepared documents will be
+            passed in using the keyword argument "documents".
         prompt: Tokenizer chat prompt template. Prepared documents will be
             passed in using the input variable "documents".
         output_parser: Output parser. Defaults to StrOutputParser.
@@ -345,10 +344,20 @@ def create_stuff_documents_chain(
 
     _output_parser = output_parser or StrOutputParser()
 
+    @chain
     def prepare_documents(inputs: dict[str, Any]) -> list[dict[str, str]]:
         documents: list[Document] = inputs[document_variable_name]
         return [{**document.metadata, "text": document.page_content} for document in documents]
 
-    return (RunnablePassthrough.assign(documents=prepare_documents).with_config(run_name="prepare_documents") | prompt | llm | _output_parser).with_config(
-        run_name="stuff_documents_chain"
-    )
+    @chain
+    def invoke_llm(inputs: dict[str, Any]) -> LanguageModelOutput:
+        prompt_value: LanguageModelInput = inputs["prompt_value"]
+        documents: list[dict[str, str]] = inputs["documents"]
+        return llm.invoke(prompt_value, documents=documents)
+
+    return (
+        RunnablePassthrough.assign(documents=prepare_documents).with_config(run_name="prepare_documents")
+        | RunnablePassthrough.assign(prompt_value=prompt).with_config(run_name="format_prompt")
+        | invoke_llm
+        | _output_parser
+    ).with_config(run_name="stuff_documents_chain")

--- a/tests/test_tokenizer_chat.py
+++ b/tests/test_tokenizer_chat.py
@@ -4,15 +4,19 @@
 
 import json
 import re
+from functools import partial
+from typing import Any
 
 import pytest
 from assertpy import assert_that
 from langchain_core.documents import Document
 from langchain_core.language_models import LanguageModelInput
-from langchain_core.messages import AIMessage, ChatMessage, HumanMessage, SystemMessage, ToolMessage
+from langchain_core.messages import AIMessage, BaseMessage, ChatMessage, HumanMessage, SystemMessage, ToolMessage, convert_to_openai_messages
+from langchain_core.output_parsers import JsonOutputParser
 from langchain_core.prompt_values import PromptValue
 from langchain_core.prompts import MessagesPlaceholder
 from langchain_core.runnables import RunnableLambda
+from transformers import PreTrainedTokenizerBase
 
 from ibm_granite_community.langchain import TokenizerChatPromptTemplate, create_stuff_documents_chain
 
@@ -59,7 +63,7 @@ class TestTokenizerChatTemplate:
             [
                 SystemMessage(content="system content"),
                 HumanMessage(content="user content1\nuser content2\n"),
-                ChatMessage(role="User", content="chat content"),
+                ChatMessage(role="user", content="chat content"),
                 AIMessage(content="assistant content"),
             ],
             tokenizer=tokenizer,
@@ -81,7 +85,7 @@ class TestTokenizerChatTemplate:
             [
                 SystemMessage(content="system content"),
                 HumanMessage(content="user content1\nuser content2\n"),
-                ChatMessage(role="User", content="chat content"),
+                ChatMessage(role="user", content="chat content"),
                 AIMessage(content="assistant content"),
             ],
             tokenizer=tokenizer,
@@ -102,7 +106,7 @@ class TestTokenizerChatTemplate:
             [
                 SystemMessage(content="system content"),
                 HumanMessage(content="user content"),
-                ChatMessage(role="User", content="chat content"),
+                ChatMessage(role="user", content="chat content"),
                 AIMessage(content="assistant content"),
                 MessagesPlaceholder("tool_results"),
             ],
@@ -150,7 +154,7 @@ class TestTokenizerChatTemplate:
             [
                 SystemMessage(content="system content"),
                 HumanMessage(content="user content"),
-                ChatMessage(role="User", content="chat content"),
+                ChatMessage(role="user", content="chat content"),
                 AIMessage(content="assistant content"),
                 MessagesPlaceholder("tool_results"),
             ],
@@ -241,13 +245,32 @@ class TestTokenizerChatTemplate:
         )
 
 
-def identity_llm(prompt: LanguageModelInput) -> str:
-    """Mock llm which returns the prompt string as its output"""
-    if isinstance(prompt, PromptValue):
-        return prompt.to_string()
-    if isinstance(prompt, str):
-        return prompt
-    raise ValueError
+def identity_llm(input: LanguageModelInput, **kwargs: Any) -> str:  # pylint: disable=redefined-builtin
+    """Mock llm which returns the prompt as its output"""
+    if not isinstance(input, PromptValue):
+        raise ValueError
+    # Use client-side prompt formatting
+    prompt = input.to_string()
+    result = json.dumps(dict(kwargs, prompt=prompt, messages=[repr(message) for message in input.to_messages()]))
+    return result
+
+
+def identity_chat_llm(tokenizer: PreTrainedTokenizerBase, input: LanguageModelInput, **kwargs: Any) -> BaseMessage:  # pylint: disable=redefined-builtin
+    """Mock chat llm which returns the prompt as its output"""
+    if not isinstance(input, PromptValue):
+        raise ValueError
+    # Emulate server-side prompt formatting (don't call input.to_string())
+    conversation = convert_to_openai_messages(input.to_messages())
+    if not isinstance(conversation, list):
+        conversation = [conversation]
+    prompt = tokenizer.apply_chat_template(
+        conversation,
+        tokenize=False,  # output is str
+        add_generation_prompt=True,
+        **kwargs,
+    )
+    result = json.dumps(dict(kwargs, prompt=prompt, messages=[repr(message) for message in input.to_messages()]))
+    return AIMessage(result)
 
 
 class TestDocumentsChain:
@@ -259,18 +282,47 @@ class TestDocumentsChain:
             "user content",
             tokenizer=tokenizer,
         )
-        chain = create_stuff_documents_chain(llm=llm, prompt=prompt_template, document_variable_name=document_variable_name)
+        chain = create_stuff_documents_chain(llm=llm, prompt=prompt_template, document_variable_name=document_variable_name, output_parser=JsonOutputParser())
         documents = [
             Document(page_content="doc 49 text", metadata={"doc_id": 49}),
             Document(page_content="doc 12 text", metadata={"doc_id": 12}),
         ]
-        text = chain.invoke(input={document_variable_name: documents})
+        result = chain.invoke(input={document_variable_name: documents})
         (
-            assert_that(text)
+            assert_that(result["prompt"])
             .matches(r"(?ms)<\|start_of_role\|>user<\|end_of_role\|>\s*?user content\s*?<\|end_of_text\|>")
             .contains(*(document.page_content for document in documents))
             .ends_with("<|start_of_role|>assistant<|end_of_role|>")
         )
+        assert_that(result["messages"]).is_length(1)
+        assert_that(result["messages"][0]).contains("user content")
+        assert_that(result["documents"]).extracting("text").contains(*(document.page_content for document in documents))
+        assert_that(result["documents"]).extracting("doc_id").contains(*(document.metadata["doc_id"] for document in documents))
+
+    @pytest.mark.parametrize("document_variable_name", ["context", "custom_name"])
+    def test_documents_chain_chat(self, tokenizer, document_variable_name):
+        assert_that(tokenizer).is_not_none()
+        llm = RunnableLambda(partial(identity_chat_llm, tokenizer))
+        prompt_template = TokenizerChatPromptTemplate.from_template(
+            "user content",
+            tokenizer=tokenizer,
+        )
+        chain = create_stuff_documents_chain(llm=llm, prompt=prompt_template, document_variable_name=document_variable_name, output_parser=JsonOutputParser())
+        documents = [
+            Document(page_content="doc 49 text", metadata={"doc_id": 49}),
+            Document(page_content="doc 12 text", metadata={"doc_id": 12}),
+        ]
+        result = chain.invoke(input={document_variable_name: documents})
+        (
+            assert_that(result["prompt"])
+            .matches(r"(?ms)<\|start_of_role\|>user<\|end_of_role\|>\s*?user content\s*?<\|end_of_text\|>")
+            .contains(*(document.page_content for document in documents))
+            .ends_with("<|start_of_role|>assistant<|end_of_role|>")
+        )
+        assert_that(result["messages"]).is_length(1)
+        assert_that(result["messages"][0]).contains("user content")
+        assert_that(result["documents"]).extracting("text").contains(*(document.page_content for document in documents))
+        assert_that(result["documents"]).extracting("doc_id").contains(*(document.metadata["doc_id"] for document in documents))
 
     def test_documents_chain_bind(self, tokenizer):
         assert_that(tokenizer).is_not_none()
@@ -285,15 +337,101 @@ class TestDocumentsChain:
                 HumanMessage(content="user content"),
             ]
         )
-        chain = create_stuff_documents_chain(llm=llm, prompt=prompt_template)
+        chain = create_stuff_documents_chain(llm=llm, prompt=prompt_template, output_parser=JsonOutputParser())
         documents = [
             Document(page_content="doc 49 text", metadata={"doc_id": 49}),
             Document(page_content="doc 12 text", metadata={"doc_id": 12}),
         ]
-        text = chain.invoke(input={"context": documents})
+        result = chain.invoke(input={"context": documents})
         (
-            assert_that(text)
+            assert_that(result["prompt"])
             .matches(r"(?ms)<\|start_of_role\|>user<\|end_of_role\|>\s*?user content\s*?<\|end_of_text\|>")
             .contains(*(document.page_content for document in documents))
             .ends_with("<|start_of_role|>assistant<|end_of_role|>")
         )
+        assert_that(result["messages"]).is_length(1)
+        assert_that(result["messages"][0]).contains("user content")
+        assert_that(result["documents"]).extracting("text").contains(*(document.page_content for document in documents))
+        assert_that(result["documents"]).extracting("doc_id").contains(*(document.metadata["doc_id"] for document in documents))
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("document_variable_name", ["context", "custom_name"])
+    async def test_documents_chain_async(self, tokenizer, document_variable_name):
+        assert_that(tokenizer).is_not_none()
+        llm = RunnableLambda(identity_llm)
+        prompt_template = TokenizerChatPromptTemplate.from_template(
+            "user content",
+            tokenizer=tokenizer,
+        )
+        chain = create_stuff_documents_chain(llm=llm, prompt=prompt_template, document_variable_name=document_variable_name, output_parser=JsonOutputParser())
+        documents = [
+            Document(page_content="doc 49 text", metadata={"doc_id": 49}),
+            Document(page_content="doc 12 text", metadata={"doc_id": 12}),
+        ]
+        result = await chain.ainvoke(input={document_variable_name: documents})
+        (
+            assert_that(result["prompt"])
+            .matches(r"(?ms)<\|start_of_role\|>user<\|end_of_role\|>\s*?user content\s*?<\|end_of_text\|>")
+            .contains(*(document.page_content for document in documents))
+            .ends_with("<|start_of_role|>assistant<|end_of_role|>")
+        )
+        assert_that(result["messages"]).is_length(1)
+        assert_that(result["messages"][0]).contains("user content")
+        assert_that(result["documents"]).extracting("text").contains(*(document.page_content for document in documents))
+        assert_that(result["documents"]).extracting("doc_id").contains(*(document.metadata["doc_id"] for document in documents))
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("document_variable_name", ["context", "custom_name"])
+    async def test_documents_chain_chat_async(self, tokenizer, document_variable_name):
+        assert_that(tokenizer).is_not_none()
+        llm = RunnableLambda(partial(identity_chat_llm, tokenizer))
+        prompt_template = TokenizerChatPromptTemplate.from_template(
+            "user content",
+            tokenizer=tokenizer,
+        )
+        chain = create_stuff_documents_chain(llm=llm, prompt=prompt_template, document_variable_name=document_variable_name, output_parser=JsonOutputParser())
+        documents = [
+            Document(page_content="doc 49 text", metadata={"doc_id": 49}),
+            Document(page_content="doc 12 text", metadata={"doc_id": 12}),
+        ]
+        result = await chain.ainvoke(input={document_variable_name: documents})
+        (
+            assert_that(result["prompt"])
+            .matches(r"(?ms)<\|start_of_role\|>user<\|end_of_role\|>\s*?user content\s*?<\|end_of_text\|>")
+            .contains(*(document.page_content for document in documents))
+            .ends_with("<|start_of_role|>assistant<|end_of_role|>")
+        )
+        assert_that(result["messages"]).is_length(1)
+        assert_that(result["messages"][0]).contains("user content")
+        assert_that(result["documents"]).extracting("text").contains(*(document.page_content for document in documents))
+        assert_that(result["documents"]).extracting("doc_id").contains(*(document.metadata["doc_id"] for document in documents))
+
+    def test_documents_chain_bind_chat(self, tokenizer):
+        assert_that(tokenizer).is_not_none()
+        llm = RunnableLambda(partial(identity_chat_llm, tokenizer))
+        prompt_template = TokenizerChatPromptTemplate.from_messages(
+            messages=[
+                MessagesPlaceholder("user_content"),
+            ],
+            tokenizer=tokenizer,
+        ).bind(
+            user_content=[
+                HumanMessage(content="user content"),
+            ]
+        )
+        chain = create_stuff_documents_chain(llm=llm, prompt=prompt_template, output_parser=JsonOutputParser())
+        documents = [
+            Document(page_content="doc 49 text", metadata={"doc_id": 49}),
+            Document(page_content="doc 12 text", metadata={"doc_id": 12}),
+        ]
+        result = chain.invoke(input={"context": documents})
+        (
+            assert_that(result["prompt"])
+            .matches(r"(?ms)<\|start_of_role\|>user<\|end_of_role\|>\s*?user content\s*?<\|end_of_text\|>")
+            .contains(*(document.page_content for document in documents))
+            .ends_with("<|start_of_role|>assistant<|end_of_role|>")
+        )
+        assert_that(result["messages"]).is_length(1)
+        assert_that(result["messages"][0]).contains("user content")
+        assert_that(result["documents"]).extracting("text").contains(*(document.page_content for document in documents))
+        assert_that(result["documents"]).extracting("doc_id").contains(*(document.metadata["doc_id"] for document in documents))


### PR DESCRIPTION
This is necessary when using a chat model since the prompt is not formatted on the client side. Instead the parts (messages, tools, documents) are passed in the REST payload to the server side for prompt formatting.

