### PR TITLE
ci: We don't need uv to emit download progress output

### DIFF
--- a/.github/workflows/test_notebook.yaml
+++ b/.github/workflows/test_notebook.yaml
@@ -78,6 +78,7 @@ on:
 
 env:
   LC_ALL: en_US.UTF-8
+  UV_NO_PROGRESS: 'true'
 
 defaults:
   run:


### PR DESCRIPTION
https: //docs.astral.sh/uv/reference/environment/#uv_no_progress

