### PR TITLE
chore: Add SPDX license identifiers and update GitHub Actions

### DIFF
--- a/.github/actions/python_setup/action.yaml
+++ b/.github/actions/python_setup/action.yaml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 name: 'python_setup'
 description: 'Setup for Python and uv'
 
@@ -5,21 +7,17 @@ inputs:
   python-version:
     description: 'Python version, supporting MAJOR.MINOR only'
     required: true
-    type: string
   uv-version:
     description: 'uv version, default latest'
     required: false
-    type: string
     default: 'latest'
   enable-cache:
     description: 'Enable caching uv cache, default true'
     required: false
-    type: boolean
-    default: true
+    default: 'true'
   save-cache:
     description: 'Save the uv cache, false if pull_request'
     required: false
-    type: boolean
     default: ${{ github.event_name != 'pull_request' }}
 
 runs:
@@ -33,7 +31,7 @@ runs:
 
     - name: 'Setup uv ${{ inputs.uv-version }}'
       id: setup-uv
-      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+      uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
       with:
         python-version: ${{ steps.setup-python.outputs.python-version }}
         version: ${{ inputs.uv-version }}

--- a/.github/pinact.yaml
+++ b/.github/pinact.yaml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 version: 3
 min_age: # cooldown
   value: 7

--- a/.github/workflows/test_notebook.yaml
+++ b/.github/workflows/test_notebook.yaml
@@ -161,7 +161,7 @@ jobs:
       - name: Free Disk Space
         if: ${{ inputs.free-disk-space }}
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
-        with: ${{ fromJSON(startsWith(inputs.free-disk-space, '{') && inputs.free-disk-space || '{}') }}
+        with: ${{ fromJSON(startsWith(inputs.free-disk-space, '{') && inputs.free-disk-space || '{}') }}  # zizmor: ignore[obfuscation]
 
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -222,7 +222,7 @@ jobs:
           NOTEBOOK: ${{ matrix.notebook }}
 
       - name: Test ${{ matrix.notebook }}
-        run: |
+        run: | # zizmor: ignore[template-injection]
           uv run --isolated --with-requirements "$REQUIREMENTS_TXT" -- ${{ inputs.command }}
           uv cache prune --ci
         env:

--- a/.poutine.yml
+++ b/.poutine.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 ignoreForks: true
 
 skip:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 # Run `pre-commit install` to activate pre-commit hooks


### PR DESCRIPTION
# Summary

This pull request adds SPDX license identifiers to configuration files, updates the `setup-uv` action to v8.2.0, removes type specifications from GitHub Action inputs, and adds security scanner exception comments for known safe patterns.

# Files Changed

📄 `.github/actions/python_setup/action.yaml`

Added Apache-2.0 SPDX license identifier, updated the `astral-sh/setup-uv` action from v8.1.0 to v8.2.0, removed `type` specifications from input parameters (as these are not supported in composite actions), and changed the `enable-cache` default from boolean `true` to string `'true'` for consistency.

📄 `.github/pinact.yaml`

Added Apache-2.0 SPDX license identifier header to the pinact configuration file.

📄 `.github/workflows/test_notebook.yaml`

Added inline comments to suppress zizmor security warnings for two known safe patterns: a `fromJSON` call with obfuscation detection (`zizmor: ignore[obfuscation]`) and a template injection in a run command (`zizmor: ignore[template-injection]`). Also fixed trailing whitespace.

📄 `.poutine.yml`

Added Apache-2.0 SPDX license identifier header to the Poutine security scanner configuration file.

📄 `.pre-commit-config.yaml`

Added Apache-2.0 SPDX license identifier header to the pre-commit hooks configuration file.